### PR TITLE
Bug #77138: Update DB schema syntax

### DIFF
--- a/event.sql
+++ b/event.sql
@@ -1,3 +1,4 @@
+SET SESSION sql_mode = '';
 #
 # Table structure for table 'phpcal'
 #

--- a/event.sql
+++ b/event.sql
@@ -22,5 +22,5 @@ CREATE TABLE phpcal (
   KEY country (country),
   KEY category (category),
   FULLTEXT KEY sdesc (sdesc,ldesc,email)
-) TYPE=MyISAM;
+) ENGINE=MyISAM;
 

--- a/mirrors.sql
+++ b/mirrors.sql
@@ -30,5 +30,5 @@ CREATE TABLE mirrors (
   ipv6_addr varchar(55) default NULL,
   PRIMARY KEY  (id),
   UNIQUE KEY hostname (hostname)
-) TYPE=MyISAM;
+) ENGINE=MyISAM;
 

--- a/mirrors.sql
+++ b/mirrors.sql
@@ -1,3 +1,4 @@
+SET SESSION sql_mode = '';
 --
 -- Table structure for table 'mirrors'
 --

--- a/note.sql
+++ b/note.sql
@@ -1,3 +1,4 @@
+SET SESSION sql_mode = '';
 /* the note table holds notes for the php manual. */
 /* TODO: there is a similar table for php-gtk's manual. it should probably be
    merged with this one. */

--- a/note.sql
+++ b/note.sql
@@ -26,13 +26,13 @@ CREATE TABLE IF NOT EXISTS note (
   updated datetime NOT NULL default '0000-00-00 00:00:00',
   PRIMARY KEY  (id),
   KEY idx_sect (sect)
-) TYPE=MyISAM PACK_KEYS=1;
+) ENGINE=MyISAM PACK_KEYS=1;
 
 CREATE TABLE IF NOT EXISTS alerts (
   user INT NOT NULL default '0',
   sect VARCHAR(80) not NULL default '',
-  updated TIMESTAMP(14) NOT NULL
-) TYPE=MyISAM;
+  updated TIMESTAMP NOT NULL
+) ENGINE=MyISAM;
 
 -- New votes table added for keeping track of user notes ratings 
 CREATE TABLE IF NOT EXISTS `votes` (
@@ -45,4 +45,4 @@ CREATE TABLE IF NOT EXISTS `votes` (
   PRIMARY KEY (`id`),
   KEY `note_id` (`note_id`,`ip`,`vote`),
   KEY `hostip` (`hostip`)
-) TYPE=MyISAM AUTO_INCREMENT=1;
+) ENGINE=MyISAM AUTO_INCREMENT=1;

--- a/users.sql
+++ b/users.sql
@@ -48,7 +48,7 @@ CREATE TABLE users (
   UNIQUE KEY email (email),
   UNIQUE KEY username (username),
   FULLTEXT KEY name (name,email,username)
-) TYPE=MyISAM;
+) ENGINE=MyISAM;
 
 /* the user_note table just contains notes about each user. */
 CREATE TABLE users_note (
@@ -58,7 +58,7 @@ CREATE TABLE users_note (
   note text,
   PRIMARY KEY  (noteid),
   FULLTEXT KEY note (note)
-) TYPE=MyISAM;
+) ENGINE=MyISAM;
 
 /* the users_profile table contains up to one profile row for each user */
 CREATE TABLE users_profile (

--- a/users.sql
+++ b/users.sql
@@ -1,3 +1,4 @@
+SET SESSION sql_mode = '';
 /* user-related tables */
 
 /* various things that may hang off the users table in the future:


### PR DESCRIPTION
These 2 patches fix issues importing the db schema for MySQL versions up through
5.7.

* Fixed in b7be6faf0c: [`ERROR 1064 (42000)`](
https://stackoverflow.com/questions/11471075#11471133
)`at line 5: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'TYPE=MyISAM' at line 21`


* Fixed in b7be6faf0c: [`ERROR 1426 (42000)`](
https://stackoverflow.com/questions/11703098#11703117
)` at line 31: Too big precision 14 specified for 'updated'. Maximum is 6`

* Fixed in 05cccaade6: [`ERROR 1067 (42000)`](
https://stackoverflow.com/questions/36882149#37696251
)` at line 5: Invalid default value for 'created'`
