### PR TITLE
Add ED25519 as supported ssh key format

### DIFF
--- a/include/functions.inc
+++ b/include/functions.inc
@@ -244,7 +244,7 @@ function verify_ssh_keys($string) {
 
 function get_ssh_keys($string) {
     $results = [];
-    if (preg_match_all('@(ssh-(?:rsa|dss) ([^\s]+) ([^\s]*))@', $string, $matches, PREG_SET_ORDER)) {
+    if (preg_match_all('@(ssh-(?:rsa|dss|ed25519) ([^\s]+) ([^\s]*))@', $string, $matches, PREG_SET_ORDER)) {
         foreach ($matches as $match) {
             $results[] = ['key'  => $match[1],
                                'name' => $match[3]];


### PR DESCRIPTION
format has been supported by github for a couple of years. It has nice short keys as can be seen @ https://github.com/SjonHortensius.keys