### PR TITLE
Update `*.php.net` URLs to HTTPS

### DIFF
--- a/public/entry/user-note.php
+++ b/public/entry/user-note.php
@@ -124,7 +124,7 @@ if (db_query_safe($query, [$user, $note, $sect])) {
 //  $msg .= $spam_data;
 //  $msg .= "\n----\n";
 
-  $msg .= "Manual Page -- http://php.net/manual/en/$sect.php\n";
+  $msg .= "Manual Page -- https://php.net/manual/en/$sect.php\n";
   $msg .= "Edit        -- https://main.php.net/note/edit/$new_id\n";
   //$msg .= "Approve     -- https://main.php.net/manage/user-notes.php?action=approve+$new_id&report=yes\n";
   foreach ($note_del_reasons AS $reason) {

--- a/public/fetch/index.php
+++ b/public/fetch/index.php
@@ -1,3 +1,3 @@
 <?php
-header("Location: http://php.net/");
+header("Location: https://php.net/");
 ?>

--- a/public/fetch/user-notes-rss.php
+++ b/public/fetch/user-notes-rss.php
@@ -55,7 +55,7 @@ header('Content-type: text/xml');
   </channel>
   <image rdf:about="http://php.net/images/php.gif">
     <title>PHP Manual User Notes</title>
-    <url>http://php.net/images/php.gif</url>
+    <url>https://www.php.net/images/php.gif</url>
     <link>https://main.php.net/manage/user-notes.php</link>
   </image>
 <?php

--- a/public/index.php
+++ b/public/index.php
@@ -1,2 +1,2 @@
 <?php
-header("Location: http://php.net/");
+header("Location: https://php.net/");

--- a/public/login.php
+++ b/public/login.php
@@ -5,7 +5,7 @@ if (isset($_GET['action']) && $_GET['action'] == 'logout') {
         session_start();
         session_destroy();
         echo 'You have successfully logged out.  Redirecting....'.PHP_EOL;
-        echo '<meta http-equiv="refresh" content="5;http://php.net/"/>'.PHP_EOL;
+        echo '<meta http-equiv="refresh" content="5;https://php.net/"/>'.PHP_EOL;
         exit(0);
 }
 

--- a/public/manage/github.php
+++ b/public/manage/github.php
@@ -135,7 +135,7 @@ includes disabling the GitHub wiki and issue tracker as well as enabling the
 php-pulls user to push changes made on git.php.net.</p>
 <p>The name, description and homepage should follow other existing repositories.</p>
 <form method="post" action="github.php">
-Github repo name: http://github.com/php/<input name="name"> (i.e. pecl-category-foobar)<br>
+Github repo name: https://github.com/php/<input name="name"> (i.e. pecl-category-foobar)<br>
 Description: <input name="description"> (i.e. PECL foobar extension)<br>
 Homepage: <input name="homepage"> (i.e. http://pecl.php.net/package/foobar)<br>
 <input type="submit" value="Create Repository on GitHub">

--- a/public/manage/user-notes.php
+++ b/public/manage/user-notes.php
@@ -21,16 +21,16 @@ those issues.
 
 The user contributed notes are not an appropriate place to
 ask questions, report bugs or suggest new features; please
-use the resources listed on <http://php.net/support>
+use the resources listed on <https://php.net/support>
 for those purposes. This was clearly stated in the page
 you used to submit your note, please carefully re-read
 those instructions before submitting future contributions.
 
 Bug submissions and feature requests should be entered at
-<http://bugs.php.net/>. For documentation errors use the
+<https://bugs.php.net/>. For documentation errors use the
 bug system, and classify the bug as "Documentation problem".
 Support and ways to find answers to your questions can be found
-at <http://php.net/support>.
+at <https://php.net/support>.
 
 Your note has been removed from the online manual.';
 
@@ -314,8 +314,8 @@ if (!$action) {
           $row['vote'] = '<span style="color: ' . ($row['vote'] ? 'green;">+1' : 'red;">-1') . '</span>';
           $row['hostip'] = long2ip($row['hostip']);
           $row['ip'] = long2ip($row['ip']);
-          $notelink = "http://php.net/{$row['sect']}#{$row['note_id']}";
-          $sectlink = "http://php.net/{$row['sect']}";
+          $notelink = "https://php.net/{$row['sect']}#{$row['note_id']}";
+          $sectlink = "https://php.net/{$row['sect']}";
           echo "    <tr style=\"background-color: #F0F0F0;\">\n".
                "      <td style=\"padding: 5px;\"><input type=\"checkbox\" name=\"deletevote[]\" class=\"vdelids\" value=\"{$row['id']}\" /></td>\n".
                "      <td style=\"padding: 5px;\">{$row['ts']}</td>\n".
@@ -343,7 +343,7 @@ if (!$action) {
                "<br /><span class=\"author\">",date("d-M-Y h:i",$row['ts'])," ",
           hsc($row['user']),"</span><br />",
                "Note id: $id<br />\n",
-               "<a href=\"http://php.net/manual/en/{$row['sect']}.php#{$id}\" target=\"_blank\">http://php.net/manual/en/{$row['sect']}.php#{$id}</a><br />\n",
+               "<a href=\"https://php.net/manual/en/{$row['sect']}.php#{$id}\" target=\"_blank\">http://php.net/manual/en/{$row['sect']}.php#{$id}</a><br />\n",
                "<a href=\"https://main.php.net/note/edit/$id\" target=\"_blank\">Edit Note</a><br />";
           foreach ($note_del_reasons AS $reason => $text) {
             echo '<a href="https://main.php.net/note/delete/', $id, '/', urlencode((string)$reason), '" target=\"_blank\">', 'Delete Note: ', hsc($text), "</a><br />\n";
@@ -590,7 +590,7 @@ case 'edit':
             $cuser,
             $id,
             "note {$row['id']} modified in {$row['sect']} by $cuser",
-            $note."\n\n--was--\n{$row['note']}\n\nhttp://php.net/manual/en/{$row['sect']}.php"
+            $note."\n\n--was--\n{$row['note']}\n\nhttps://php.net/manual/en/{$row['sect']}.php"
         );
         if ($row["sect"] != $sect) {
           note_mail_user($email, "note $id moved from $row[sect] to $sect by notes editor $cuser", "----- Copy of your note below -----\n\n".$note);

--- a/public/manage/users.php
+++ b/public/manage/users.php
@@ -256,7 +256,7 @@ if ($id) {
     }
 ?>
 <tr>
- <th>People Profile<br>(<a href="http://people.php.net/user.php?username=<?php echo urlencode($userdata['username']);?>"><?php echo hsc($userdata['username']);?>'s page</a>)</th>
+ <th>People Profile<br>(<a href="https://people.php.net/user.php?username=<?php echo urlencode($userdata['username']);?>"><?php echo hsc($userdata['username']);?>'s page</a>)</th>
  <td>
      <p>Use <a href="http://michelf.ca/projects/php-markdown/dingus/" title="PHP Markdown: Dingus">Markdown</a>. Type as much as you like.</p>
      <div><textarea name="in[profile_markdown]" placeholder="My PHP People page content"><?php echo hsc($userdata['profile_markdown']); ?></textarea></div>

--- a/public/network/status/index.php
+++ b/public/network/status/index.php
@@ -1,4 +1,4 @@
 <?php
 
-header('Location: http://php.net');
+header('Location: https://php.net');
 exit;

--- a/scripts/email-note-summaries
+++ b/scripts/email-note-summaries
@@ -17,7 +17,7 @@ $body = "Notes  |  Page\n"
 
 $top20 = 0;
 while ($row = mysql_fetch_array($res,MYSQL_ASSOC)) {
-  $body .= sprintf("%5d  | http://php.net/manual/en/%s.php\n", $row['count'], $row['sect']);
+  $body .= sprintf("%5d  | https://php.net/manual/en/%s.php\n", $row['count'], $row['sect']);
   $top20 += $row['count'];
 }
 

--- a/scripts/index.php
+++ b/scripts/index.php
@@ -1,3 +1,3 @@
 <?php
-header("Location: http://php.net/");
+header("Location: https://php.net/");
 ?>


### PR DESCRIPTION
Updated existing `*.php.net` absolute URLs to use `https://`.
This includes redirects, links, and image source URLs to `php.net`, `people.php.net`, and `bugs.php.net`, all of which redirect to HTTPS.
Updating the hardcoded URLs from `http://` to `https://` should reduce the slight change of MITM that intercept the redirect response from `http://` URLs.