### PR TITLE
fix: cvs auth

### DIFF
--- a/public/fetch/cvsauth.php
+++ b/public/fetch/cvsauth.php
@@ -35,8 +35,7 @@ echo $a["SUCCESS"], "\n";
 
 use App\DB;
 
-require 'functions.inc';
-require 'cvs-auth.inc';
+require_once __DIR__.'/../../vendor/autoload.php';
 
 # Error constants
 define("E_UNKNOWN", 0);


### PR DESCRIPTION
Now it gives an error 500.
Accordingly, authorization on sites *.php.net doesn't work.