### PR TITLE
Update sender of notes email

### DIFF
--- a/public/entry/user-note.php
+++ b/public/entry/user-note.php
@@ -132,7 +132,7 @@ $msg .= "Search      -- https://main.php.net/manage/user-notes.php\n";
 if (!$user) $user = "php-general@lists.php.net";
 # strip spaces in email address, or will get a bad To: field
 $user = str_replace(' ','',$user);
-mail($mailto,"note $new_id added to $sect",$msg,"From: $user\r\nMessage-ID: <note-$new_id@php.net>", "-fnoreply@php.net");
+mail($mailto,"note $new_id added to $sect",$msg,"From: \"$user\"<noreply@php.net>\r\nMessage-ID: <note-$new_id@php.net>", "-fnoreply@php.net");
 
 //var_dump(is_spammer('127.0.0.1')); // false
 //var_dump(is_spammer('127.0.0.2')); // true


### PR DESCRIPTION
This updates the sender of the notes email to the noreply@php.net email-address that has the entered email-address of the user as name.

That way the email should be recognized by the lists-server as noreply@php.net is a subscribed list-user

Currently emails to the notes-list are sent with the users email-address as from header and that most of the time that user is not subscribed to the list and will therefore receive a bounce message and the message itself will not reach the list. 

This should fix that behaviour so that list-messages will again hit the lists-mailinglist