### PR TITLE
Don't send mail on review_request_removed

### DIFF
--- a/public/github-webhook.php
+++ b/public/github-webhook.php
@@ -379,6 +379,7 @@ switch ($event) {
             case 'demilestoned':
             case 'ready_for_review':
             case 'review_requested':
+            case 'review_request_removed':
                 // Ignore these actions
                 break 2;
             default:


### PR DESCRIPTION
I assigned to you @derickr because it probably needs to be deployed. You can do so whenever is convenient for you, this isn't a priority.