### PR TITLE
Stop allowing DSA keys, start allowing ED25519

### DIFF
--- a/include/functions.inc
+++ b/include/functions.inc
@@ -171,7 +171,7 @@ function verify_ssh_keys($string) {
 
 function get_ssh_keys($string) {
     $results = [];
-    if (preg_match_all('@(ssh-(?:rsa|dss) ([^\s]+) ([^\s]*))@', $string, $matches, PREG_SET_ORDER)) {
+    if (preg_match_all('@(ssh-(?:rsa|ed25519) ([^\s]+) ([^\s]*))@', $string, $matches, PREG_SET_ORDER)) {
         foreach ($matches as $match) {
             $results[] = ['key'  => $match[1],
                                'name' => $match[3]];


### PR DESCRIPTION
It's 2024, DSA is long past its shelf-life and ED25519 should be supported by everything.