### PR TITLE
Change user_profile table to utf8mb4 and set on connection

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -263,7 +263,7 @@ CREATE TABLE `users_profile` (
   `markdown` text NOT NULL,
   `html` text NOT NULL,
   PRIMARY KEY (`userid`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --


### PR DESCRIPTION
Resolves https://github.com/php/web-master/issues/36

The `user_profile` table is the only table using `utf8`; changing it to `utf8mb4` allows all four emojis to be saved in the profile table.

```
CREATE TABLE `users_profile` (
  `userid` int(11) NOT NULL,
  `markdown` text NOT NULL,
  `html` text NOT NULL,
  PRIMARY KEY (`userid`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
```

Query to alter table: `ALTER TABLE users_profile CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;`

I freely admit this is a me and my emoji issue 🚀 🐘🐘🐘🐘🐘  